### PR TITLE
Feat: add ssl option on connection class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 src/**/*.js
 .rts2_cache_*
+certs

--- a/examples/secure-connection/ssl-connection.js
+++ b/examples/secure-connection/ssl-connection.js
@@ -1,0 +1,50 @@
+const amqpPlus = require("amqplib-plus");
+const fs = require('fs');
+
+// For secure connection we MUST appoint the connection params with AMPQS insted of AMQP because AMQPS is the secure protocol to amqp.
+// The port changes from 5672 to 5671
+// You can see all details about SSL Connection here: https://www.rabbitmq.com/ssl.html
+const options = {
+	connectionString: 'amqps://guest:guest@localhost:5671/',
+	heartbeat: 60,
+	ssl: {
+		cert: fs.readFileSync('cert.pem'),
+		key: fs.readFileSync('key.pem'),			
+		// Or you can appoint a PFX certificate instead of cert and key
+		// pfx: fs.readFileSync('pfx.pem'),
+		// And
+		passphrase: 'its-a-test,',
+		ca: fs.readFileSync('ca.pem'),
+	}
+};
+
+// At this moment, if you pass the ssl params on options automatically the Connection below will try to connect using the certificates.
+const connection = new amqpPlus.Connection(options);
+
+async function run() {
+	await connection.connect();
+
+	const channel = await connection.createChannel(async (ch) => {
+		// do whatever channel setup you want before you return it
+		await ch.assertQueue("first-queue", { durable: false });
+	});
+
+	// now there already exists the asserted queue and wi can rely on it
+	await channel.sendToQueue("first-queue", Buffer.from("Check your rabbit mq instance for this message"));
+
+	// You can create as many channels as you need
+	const anotherChannel = await connection.createChannel(async (ch) => {
+		// do whatever channel setup you want before you return it
+	});
+
+	// or we can asser queue here if we do not want to do it in prepare function
+	await channel.assertQueue("second-queue", { durable: false });
+
+	await anotherChannel.prefetch(1);
+	await anotherChannel.consume("second-queue", (msg) => {
+		console.log(msg.content.toString());
+		channel.ack(msg);
+	});
+}
+
+run();

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -9,11 +9,11 @@ const WAIT_MS: number = 2000;
 const WAIT_MAX_MS: number = 300000; // 5 * 60 * 1000 = 5 min
 
 export interface IConnectionSSLOptions {
-  cert?: string;
-  key?: string;
-  pfx?: string;
+  cert?: Buffer;
+  key?: Buffer;
+  pfx?: Buffer;
   passphrase?: string;
-  ca?: string;
+  ca?: Buffer;
 }
 
 export interface IConnectionOptions {
@@ -57,16 +57,16 @@ export class Connection {
     if(opts.ssl){
       if(opts.ssl.pfx){
         this.sslOptions = {
-          pfx: fs.promises.readFile(path.resolve(__dirname, '..', 'certs', opts.ssl.pfx)),
+          pfx: opts.ssl.pfx,
           passphrase: opts.ssl.passphrase ?? undefined,
-          ca: [fs.promises.readFile(path.resolve(__dirname, '..', 'certs', opts.ssl.ca))]
+          ca: [opts.ssl.ca]
         }
       } else {
         this.sslOptions = {
-          cert: fs.promises.readFile(path.resolve(__dirname, '..', 'certs', opts.ssl.cert)),
-          key: fs.promises.readFile(path.resolve(__dirname, '..', 'certs', opts.ssl.key)),
+          cert: opts.ssl.cert,
+          key: opts.ssl.key,
           passphrase: opts.ssl.passphrase ?? undefined,
-          ca: [fs.promises.readFile(path.resolve(__dirname, '..', 'certs', opts.ssl.ca))]
+          ca: [opts.ssl.ca]
         }
       }      
     }

--- a/test/unit/Connection.test.ts
+++ b/test/unit/Connection.test.ts
@@ -31,4 +31,20 @@ describe("Connection", () => {
     expect(conn.getConnectionString()).toEqual("amqp://rabbit:5672/root");
     conn.close();
   });
+
+  it("should accept ssl options to connect", async () => {
+    const opts = {
+      cert: 'cert.pem',
+      key: 'key.pem',
+      passphrase: '123',
+      ca: 'ca.pem'
+    }
+    const conn = new Connection({
+      connectionString: "amqp://rabbit:5672/root",
+      ssl: opts
+    });
+
+    expect(conn.getSSLOptions()).toBeDefined();
+    conn.close();
+  });
 });

--- a/test/unit/Connection.test.ts
+++ b/test/unit/Connection.test.ts
@@ -1,4 +1,6 @@
 import { Connection } from "@src/Connection";
+import fs from 'fs';
+import path from 'path';
 
 describe("Connection", () => {
   it("should accept connection string", async () => {
@@ -33,14 +35,16 @@ describe("Connection", () => {
   });
 
   it("should accept ssl options to connect", async () => {
+    const mockFile = "123";
+
     const opts = {
-      cert: 'cert.pem',
-      key: 'key.pem',
+      cert: Buffer.from(mockFile),
+      key: Buffer.from(mockFile),
       passphrase: '123',
-      ca: 'ca.pem'
+      ca: Buffer.from(mockFile)
     }
     const conn = new Connection({
-      connectionString: "amqp://rabbit:5672/root",
+      connectionString: "amqps://rabbit:5671",
       ssl: opts
     });
 


### PR DESCRIPTION
Hi, @kedlas 

I recently discover this awesome library, so I needed to add ssl option on connection but I saw that this library isn't compatible with SSL #7. So I decided to contribute and add this option by myself.

I saw this page on RabbitMQ website and followed the instructions in how to do that thing. 
https://www.rabbitmq.com/ssl.html

I already build the library and tested in my application and until now its working pretty well.

I added one test and one ssl connection example